### PR TITLE
Fix bug in which alternate divisors were not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Mastering Git: Forking Workflow Sample Project
+# Advanced Git: Forking Workflow Sample Project
 
-This is the sample project for the Forking Workflow chapter of the [RayWenderlich Mastering Git](https://store.raywenderlich.com/products/mastering-git) book.
+This is the sample project for the Forking Workflow chapter of the [RayWenderlich Advanced Git](https://store.raywenderlich.com/products/advanced-git) book.

--- a/fizzbuzz.py
+++ b/fizzbuzz.py
@@ -8,8 +8,8 @@ def fizzbuzz_for_num(
     buzz_divisor=5,
     buzz_word="Buzz",
 ):
-    should_fizz = n % 3 == 0
-    should_buzz = n % 5 == 0
+    should_fizz = n % fizz_divisor == 0
+    should_buzz = n % buzz_divisor == 0
     if should_fizz and should_buzz:
         return fizz_word + buzz_word
     elif should_fizz:

--- a/fizzbuzz.py
+++ b/fizzbuzz.py
@@ -3,7 +3,9 @@
 
 def fizzbuzz_for_num(
     n,
+    fizz_divisor=3,
     fizz_word="Fizz",
+    buzz_divisor=5,
     buzz_word="Buzz",
 ):
     should_fizz = n % 3 == 0

--- a/test_fizzbuzz.py
+++ b/test_fizzbuzz.py
@@ -34,6 +34,16 @@ class TestFizzBuzz(unittest.TestCase):
         with self.subTest(msg="Alternate Words: Divisible by Both"):
             self.assertEqual(fizzbuzz_for_num(15, fizz_word="Ab", buzz_word="Cd"), "AbCd")
 
+    def test_with_alternate_divisors(self):
+        with self.subTest(msg="Alternate Divisors: Divisible by None"):
+            self.assertEqual(fizzbuzz_for_num(1, fizz_divisor=7, buzz_divisor=11), "1")
+        with self.subTest(msg="Alternate Divisors: Divisible by First"):
+            self.assertEqual(fizzbuzz_for_num(7, fizz_divisor=7, buzz_divisor=11), "Fizz")
+        with self.subTest(msg="Alternate Divisors: Divisible by Second"):
+            self.assertEqual(fizzbuzz_for_num(11, fizz_divisor=7, buzz_divisor=11), "Buzz")
+        with self.subTest(msg="Alternate Divisors: Divisible by Both"):
+            self.assertEqual(fizzbuzz_for_num(77, fizz_divisor=7, buzz_divisor=11), "FizzBuzz")
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
This commit updates the code in the fizzbuzz_for_num method to start using the fizz_divisor and buzz_divisor parameters that were added to the method signature in a previous commit Verified the fix by running existing tests in test_fizzbuzz.py which were previously failing and now are all passing